### PR TITLE
Remove trailing space in the request motion text

### DIFF
--- a/backend/routers/generate/router.py
+++ b/backend/routers/generate/router.py
@@ -13,7 +13,7 @@ stop_token = '<|endoftext|>'
 @router.post("", response_model=GenerateResponse)
 async def generate_motion(request: GenerateRequest):
     # Beginning of the motion
-    prefix = request.prefix
+    prefix = request.prefix.strip()
     # High temperature results in more "unpredictible" results
     temperature = request.temperature
 


### PR DESCRIPTION
Fixes bug when motions are not properly generated when user pass prefix with trailing space.